### PR TITLE
About socketio and python3 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Requirements: pyjs9 communicates with a JS9 back-end Node server
 (which communicates with the browser itself). By default, pyjs9 utilizes the
 `requests <http://www.python-requests.org/en/latest/>` module to
 communicate with the JS9  back-end server. However, if you install
-`socketIO_client <https://pypi.python.org/pypi/socketIO-client>`,
+`python-socketio` <https://pypi.org/project/python-socketio>`,
 pyjs9 will use the faster, persistent `socket.io http://socket.io/` protocol.
 
 Install from the repository using pip, as usual::
@@ -49,7 +49,7 @@ Optional dependencies::
 
     numpy               # support for GetNumpy and SetNumpy methods
     astropy             # support for GetFITS and SetFITS methods
-    socketIO-client     # fast, persistent socket.io protocol, instead of html
+    python-socketio     # fast, persistent socket.io protocol, instead of html
 
 To run::
 


### PR DESCRIPTION
It seems that codes are not tested fully enough under python3 and new python modules. 
 
issues:  
python3 `bytes`  generated by base64 module should be decoded to `str` before `json.dumps` .  
socketIO_client failed to connect socket.io server, change python-socketio just works.   
types such as `dtype('>i4')` could be converted to `numpy.int32` automatically.  

Commit details:
    - import python-socketio instead of socketIO_client
    - fix pylint warnings
    - check more array dtype
    - decode bytes to string for json serialization in python3